### PR TITLE
Fix initial project setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,3 @@
+// File purposely left empty.
+// This file is required so that Android Studio will properly recognise this
+// project as a Gradle-based project.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.buildFileName = 'build.gradle.kts'
+
+include ':showcase', ':tomo'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,0 @@
-include(":showcase", ":tomo")


### PR DESCRIPTION
Closes #1 

On Windows, Android Studio was not recognizing the project as a Gradle-based project. Android Studio still checking for the `build.gradle` file instead of the `build.gradle.kts` files used instead.